### PR TITLE
Feature/input and output types

### DIFF
--- a/AnomalyDetector.cs
+++ b/AnomalyDetector.cs
@@ -152,7 +152,7 @@ public class AnomalyDetector<TInputType, TAnomalyOutputType> : IAnomalyDetector<
     }
 }
 
-public class AnomalyDetector<TAnomalyOutputType> : AnomalyDetector<TAnomalyOutputType, TAnomalyOutputType> where TAnomalyOutputType : class, IAnomalyDetectionOutput, new()
-{
-    protected AnomalyDetector(MLContext mlContext) : base(mlContext) { }
-}
+// public class AnomalyDetector<TAnomalyOutputType> : AnomalyDetector<TAnomalyOutputType, TAnomalyOutputType> where TAnomalyOutputType : class, IAnomalyDetectionOutput, new()
+// {
+//     protected AnomalyDetector(MLContext mlContext) : base(mlContext) { }
+// }

--- a/AnomalyDetector.cs
+++ b/AnomalyDetector.cs
@@ -72,7 +72,7 @@ public class AnomalyDetector<TInputType, TAnomalyOutputType> : IAnomalyDetector<
 
         // STEP 2: Set the training algorithm
         var iidSpikeEstimator = _mlContext.Transforms
-        .DetectIidSpike(outputColumnName: _options.OutputColumnName, inputColumnName: _options.InputColumnName,
+        .DetectIidSpike(outputColumnName: nameof(IAnomalyDetectionOutput.Prediction), inputColumnName: _options.InputColumnName,
         confidence: 95, pvalueHistoryLength: _data.Count() / 4);
 
         // STEP 3: Create the transform
@@ -116,7 +116,7 @@ public class AnomalyDetector<TInputType, TAnomalyOutputType> : IAnomalyDetector<
 
         //STEP 2: Set the training algorithm 
         var iidChangePointEstimator = _mlContext.Transforms
-            .DetectIidChangePoint(outputColumnName: _options.OutputColumnName, inputColumnName: _options.InputColumnName, confidence: 95,
+            .DetectIidChangePoint(outputColumnName: nameof(IAnomalyDetectionOutput.Prediction), inputColumnName: _options.InputColumnName, confidence: 95,
             changeHistoryLength: _data.Count() / 4);
 
         //STEP 3: Create the transform
@@ -147,7 +147,7 @@ public class AnomalyDetector<TInputType, TAnomalyOutputType> : IAnomalyDetector<
     static IDataView CreateEmptyDataView(MLContext mlContext)
     {
         // Create empty DataView. We just need the schema to call Fit() for the time series transforms
-        IEnumerable<TAnomalyOutputType> enumerableData = new List<TAnomalyOutputType>();
+        IEnumerable<TInputType> enumerableData = new List<TInputType>();
         return mlContext.Data.LoadFromEnumerable(enumerableData);
     }
 }

--- a/AnomalyOptions.cs
+++ b/AnomalyOptions.cs
@@ -4,8 +4,7 @@ using Microsoft.ML;
 public readonly struct AnomalyOptions
 {
     public string InputColumnName {get;}
-    public string OutputColumnName {get;}
-    
-    public AnomalyOptions(string inputColumnName, string outputColumnName)
-        => (InputColumnName, OutputColumnName) = (inputColumnName, outputColumnName);
+
+    public AnomalyOptions(string inputColumnName)
+        => InputColumnName = inputColumnName;
 }

--- a/AnomalyOptions.cs
+++ b/AnomalyOptions.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using Microsoft.ML;
 
 public readonly struct AnomalyOptions

--- a/CoronavirusData.cs
+++ b/CoronavirusData.cs
@@ -17,8 +17,9 @@ public class CoronavirusData
     public Single TotalDeaths;
 }
 
-public class CoronavirusPrediction
+public class CoronavirusPrediction : CoronavirusData, IAnomalyDetectionOutput
 {
+    [NoColumn] // This isn't working atm??
     [VectorType(3)]
     public double[] Prediction { get; set; }
 }

--- a/CoronavirusData.cs
+++ b/CoronavirusData.cs
@@ -19,7 +19,6 @@ public class CoronavirusData
 
 public class CoronavirusPrediction : CoronavirusData, IAnomalyDetectionOutput
 {
-    [NoColumn] // This isn't working atm??
     [VectorType(3)]
     public double[] Prediction { get; set; }
 }

--- a/Interfaces.cs
+++ b/Interfaces.cs
@@ -1,19 +1,35 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
+using Microsoft.ML.Data;
 
-public interface IAnomalyDetectorSetOptions
+public interface IAnomalyDetector<TInputType, TAnomalyOutputType> :
+    IAnomalyDetectorLoadData<TInputType>,
+    IAnomalyDetectorSetOptions<TInputType>,
+    IAnomalyDetectorDetection<TInputType>
+    where TInputType : class, new()
+    where TAnomalyOutputType : class, IAnomalyDetectionOutput, new()
 {
-    IAnomalyDetectorDetection SetOptions(AnomalyOptions options);
 }
 
-public interface IAnomalyDetectorLoadData<TData>
+public interface IAnomalyDetectorLoadData<TInputType>
 {
-    IAnomalyDetectorSetOptions LoadDataFromFile(string path, bool hasHeaders = true, char seperator = ',');
-    IAnomalyDetectorSetOptions LoadData(IEnumerable<TData> data);
+    IAnomalyDetectorSetOptions<TInputType> LoadDataFromFile(string path, bool hasHeaders = true, char seperator = ',');
+    IAnomalyDetectorSetOptions<TInputType> LoadData(IEnumerable<TInputType> data);
+}
+public interface IAnomalyDetectorSetOptions<TInputType>
+{
+    IAnomalyDetectorDetection<TInputType> SetOptions(AnomalyOptions options);
+    IAnomalyDetectorDetection<TInputType> ManipulateData(Action<IEnumerable<TInputType>> manipulations);
 }
 
-public interface IAnomalyDetectorDetection : IAnomalyDetectorSetOptions
+public interface IAnomalyDetectorDetection<TInputType> : IAnomalyDetectorSetOptions<TInputType>
 {
-    IAnomalyDetectorDetection DetectSpike(TextWriter output);
-    IAnomalyDetectorDetection DetectChangepoint(TextWriter output);
+    IAnomalyDetectorDetection<TInputType> DetectSpike(TextWriter output);
+    IAnomalyDetectorDetection<TInputType> DetectChangepoint(TextWriter output);
+}
+
+public interface IAnomalyDetectionOutput
+{
+    double[] Prediction { get; set; }
 }

--- a/ProductSalesData.cs
+++ b/ProductSalesData.cs
@@ -8,7 +8,7 @@ public class ProductSalesData
     public float numSales;
 }
 
-public class ProductSalesPrediction
+public class ProductSalesPrediction : IAnomalyDetectionOutput
 {
     [VectorType(3)]
     public double[] Prediction { get; set; }

--- a/Program.cs
+++ b/Program.cs
@@ -11,26 +11,34 @@ namespace Covid19Analyser
         static readonly string _dataPath = Path.Combine(Environment.CurrentDirectory, "Data");
         static void Main(string[] args)
         {
-            ProcessData<ProductSalesData>("product-sales.csv", nameof(ProductSalesData.numSales));
-            ProcessData<CoronavirusData>("full_data.csv", nameof(CoronavirusData.NewCases));
-        }
+            // ProcessData<ProductSalesData>("product-sales.csv", nameof(ProductSalesData.numSales));
+            // ProcessData<CoronavirusData>("full_data.csv", nameof(CoronavirusData.NewCases));
 
-        static void ProcessData<TDataType>(string fileName, string inputColumnName, char separatorCharacter = ',') where TDataType : class, new()
-        {
-            var filePath = Path.Combine(_dataPath, fileName);
-            // Create MLContext to be shared across the model creation workflow objects 
-            MLContext mlContext = new MLContext();
+            var filePath = Path.Combine(_dataPath, "full_data.csv");
 
-            // //STEP 1: Common data loading configuration
-            // IDataView dataView = mlContext.Data.LoadFromTextFile<TDataType>(path: filePath, hasHeader: true, separatorChar: separatorCharacter);
-            // var values = mlContext.Data.CreateEnumerable<TDataType>(dataView, reuseRowObject: false);
-            // var count = values.Count();
-
-            AnomalyDetector<TDataType>
+            AnomalyDetector<CoronavirusData, CoronavirusPrediction>
                 .SetContext()
                 .LoadDataFromFile(filePath)
-                .SetOptions(new AnomalyOptions(inputColumnName, "Prediction"))
+                .ManipulateData(data => {
+                        data = from dailyCounts in data
+                        let parsedDate = DateTime.Parse(dailyCounts.Date)
+                        orderby parsedDate
+                        select dailyCounts;
+                    })
+                .SetOptions(new AnomalyOptions(nameof(CoronavirusData.NewCases), "Prediction"))
                 .DetectSpike(Console.Out);
+
         }
+
+        // static void ProcessData<TDataType>(string fileName, string inputColumnName, char separatorCharacter = ',') where TDataType : class, new()
+        // {
+        //     var filePath = Path.Combine(_dataPath, fileName);
+
+        //     AnomalyDetector<TDataType>
+        //         .SetContext()
+        //         .LoadDataFromFile(filePath)
+        //         .SetOptions(new AnomalyOptions(inputColumnName, "Prediction"))
+        //         .DetectSpike(Console.Out);
+        // }
     }
 }

--- a/Program.cs
+++ b/Program.cs
@@ -16,7 +16,7 @@ namespace Covid19Analyser
 
             var filePath = Path.Combine(_dataPath, "full_data.csv");
 
-            AnomalyDetector<CoronavirusPrediction, CoronavirusPrediction>
+            AnomalyDetector<CoronavirusData, CoronavirusPrediction>
                 .SetContext()
                 .LoadDataFromFile(filePath)
                 .ManipulateData(data => {
@@ -25,7 +25,7 @@ namespace Covid19Analyser
                         orderby parsedDate
                         select dailyCounts;
                     })
-                .SetOptions(new AnomalyOptions(nameof(CoronavirusData.NewCases), "Prediction"))
+                .SetOptions(new AnomalyOptions(nameof(CoronavirusData.NewCases)))
                 .DetectSpike(Console.Out);
 
         }

--- a/Program.cs
+++ b/Program.cs
@@ -16,7 +16,7 @@ namespace Covid19Analyser
 
             var filePath = Path.Combine(_dataPath, "full_data.csv");
 
-            AnomalyDetector<CoronavirusData, CoronavirusPrediction>
+            AnomalyDetector<CoronavirusPrediction, CoronavirusPrediction>
                 .SetContext()
                 .LoadDataFromFile(filePath)
                 .ManipulateData(data => {


### PR DESCRIPTION
# Type constraints
I've added type constraints so that the consumer can specify an output type as well as an input type have the anomaly detector logic determine the properties etc. to output based on the type rather than specifying columns as strings.